### PR TITLE
chore: MR-35 Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Curious Reader container app
 
+## Deprecation Notice
+
+This repository is deprecated and has been retired.
+
+This standalone Curious Reader Hindi app was used for an experiment to determine whether including all content directly in the Curious Reader Play Store download helped users progress further into the game funnel.
+
+That experiment has concluded, so this standalone CR Hindi app should no longer be used as the basis for ongoing development. Any future need for a standalone Curious Reader experience in Hindi should be created from a more recent branch of the production Curious Reader repository instead: https://github.com/curiouslearning/CRcontainer
+
 Overview
 
 What: The Curious Reader library app is essentially a web browser within an Android app that allows a user to launch and engage with a variety of web-based literacy content developed by Curious Learning (and partners). The app displays web-based content using a manifest and a selected language to show app icons, much like a phone homescreen.


### PR DESCRIPTION
Added a Deprecation Notice to README.md stating the standalone Curious Reader Hindi app has been retired after an experiment. The notice explains the experiment purpose (testing bundling content in Play Store builds), that the app should no longer be used as a basis for ongoing development, and points maintainers to the production Curious Reader repository: https://github.com/curiouslearning/CRcontainer.

# Changes
- README.md

# How to test
- Check README.md

Ref: [MR-35](https://curiouslearning.atlassian.net/jira/software/projects/MR/boards/76?selectedIssue=MR-35)


[MR-35]: https://curiouslearning.atlassian.net/browse/MR-35?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a deprecation notice indicating this repository is no longer maintained.
  * Users are directed to an alternative repository for future Hindi standalone development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->